### PR TITLE
Travis-ci: added support for ppc64le & Updated node-js versions 1.14 & 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+arch:
+  - amd64
+  - ppc64le
 node_js:
-  - "0.8"
-  - "0.10"
+  - "14"
+  - "15"


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture & Updated node-js versions 1.14 & 1.15 support on Travis-CI in the PR and looks like its been successfully added.

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra